### PR TITLE
Add package for openjdk-11

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ $ bosh vendor-package openjdk-9 ~/workspace/java-release
 
 Included packages:
 
+- openjdk-11
 - openjdk-9
 - openjdk-8
 

--- a/build/build.sh
+++ b/build/build.sh
@@ -42,3 +42,8 @@ echo "----> OpenJDK 9"
 pushd packages/openjdk-9/
   build_jdk
 popd
+
+echo "----> OpenJDK 11"
+pushd packages/openjdk-11/
+  build_jdk
+popd

--- a/jobs/openjdk-11-test/spec
+++ b/jobs/openjdk-11-test/spec
@@ -1,0 +1,11 @@
+---
+name: openjdk-11-test
+
+templates:
+  run: bin/run
+
+packages:
+- openjdk-11
+- openjdk-11-test
+
+properties: {}

--- a/jobs/openjdk-11-test/templates/run
+++ b/jobs/openjdk-11-test/templates/run
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -ex
+
+source /var/vcap/packages/openjdk-11/bosh/runtime.env
+
+java -version

--- a/manifests/test.yml
+++ b/manifests/test.yml
@@ -41,3 +41,15 @@ instance_groups:
   stemcell: default
   networks:
   - name: default
+
+- name: openjdk-11-test
+  azs: [z1]
+  instances: 1
+  jobs:
+  - name: openjdk-11-test
+    release: java
+    properties: {}
+  vm_type: default
+  stemcell: default
+  networks:
+  - name: default

--- a/packages/openjdk-11-test/packaging
+++ b/packages/openjdk-11-test/packaging
@@ -1,0 +1,5 @@
+set -ex
+
+source /var/vcap/packages/openjdk-11/bosh/compile.env
+
+java -version

--- a/packages/openjdk-11-test/spec
+++ b/packages/openjdk-11-test/spec
@@ -1,0 +1,7 @@
+---
+name: openjdk-11-test
+
+dependencies:
+- openjdk-11
+
+files: []

--- a/packages/openjdk-11/Dockerfile
+++ b/packages/openjdk-11/Dockerfile
@@ -1,0 +1,5 @@
+FROM ubuntu:xenial
+WORKDIR /tmp
+COPY build.sh /tmp/build.sh
+RUN chmod +x /tmp/build.sh
+RUN /tmp/build.sh

--- a/packages/openjdk-11/build.sh
+++ b/packages/openjdk-11/build.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+set -e -x -u -o pipefail
+
+major_ver=11
+minor_ver=0
+update_ver=1
+build_number=13
+
+# http://hg.openjdk.java.net/jdk-updates/jdk11u/tags
+tag=jdk-${major_ver}.${minor_ver}.${update_ver}+${build_number}
+
+echo "----> Setting up dev env"
+apt-get -y update
+apt-get -y install openjdk-8-jdk mercurial build-essential zip autoconf curl \
+  libx11-dev libxext-dev libxrender-dev libxtst-dev libxt-dev \
+  libcups2-dev libfreetype6-dev libasound2-dev libelf-dev libfontconfig1-dev \
+
+echo "----> Creating CA certs bundle"
+mkdir cacerts/
+awk '/-----BEGIN CERTIFICATE-----/,/-----END CERTIFICATE-----/{ print $0; }' \
+  /etc/ssl/certs/ca-certificates.crt | \
+  csplit -n 3 -s -f cacerts/ - '/-----BEGIN CERTIFICATE-----/' {*}
+rm cacerts/000
+for I in $(find cacerts -type f | sort) ; do
+  keytool -importcert -noprompt -keystore cacerts.jks \
+    -storepass changeit -file $I -alias $(basename $I)
+done
+
+echo "----> Downloading OpenJDK 10"
+openjdk_10_url="https://download.java.net/java/GA/jdk10/10.0.2/19aef61b38124481863b1413dce1855f/13/openjdk-10.0.2_linux-x64_bin.tar.gz"
+curl "$openjdk_10_url" | tar -xz -C /usr/lib/jvm
+
+echo "----> Cloning OpenJDK 11 repo"
+hg clone http://hg.openjdk.java.net/jdk-updates/jdk11u
+
+echo "----> Building OpenJDK 11"
+pushd jdk11u
+  chmod +x configure
+  ./configure \
+    --disable-warnings-as-errors \
+    --with-boot-jdk=/usr/lib/jvm/jdk-10.0.2/ \
+    --with-cacerts-file=$(pwd)/../cacerts.jks \
+    --with-native-debug-symbols=none \
+    --with-version-pre= \
+    --with-version-opt= \
+    --with-version-build=$build_number
+  COMPANY_NAME="github.com/bosh-packages/java-release" make images
+  chmod -R a+r build/linux-x86_64-normal-server-release/images
+  tar czvf $(pwd)/../openjdk.tar.gz -C build/linux-x86_64-normal-server-release/images/jdk .
+popd
+
+echo "----> Export"
+mkdir output/
+mv openjdk.tar.gz output/${tag}.tar.gz
+shasum -a 256 output/*.tar.gz > output/shasums
+cat output/shasums

--- a/packages/openjdk-11/packaging
+++ b/packages/openjdk-11/packaging
@@ -1,0 +1,9 @@
+set -ex
+
+mkdir ${BOSH_INSTALL_TARGET}/bosh
+cp openjdk-11/runtime.env ${BOSH_INSTALL_TARGET}/bosh/runtime.env
+cp openjdk-11/compile.env ${BOSH_INSTALL_TARGET}/bosh/compile.env
+
+cd ${BOSH_INSTALL_TARGET}
+mkdir jre
+tar zxvf ${BOSH_COMPILE_TARGET}/jdk-*.tar.gz -C jre

--- a/packages/openjdk-11/spec
+++ b/packages/openjdk-11/spec
@@ -1,0 +1,9 @@
+---
+name: openjdk-11
+
+dependencies: []
+
+files:
+- openjdk-11/compile.env
+- openjdk-11/runtime.env
+- jdk-11.0.1+13.tar.gz

--- a/src/openjdk-11/compile.env
+++ b/src/openjdk-11/compile.env
@@ -1,0 +1,2 @@
+export JAVA_HOME=/var/vcap/packages/openjdk-11/jre
+export PATH=$JAVA_HOME/bin:$PATH

--- a/src/openjdk-11/runtime.env
+++ b/src/openjdk-11/runtime.env
@@ -1,0 +1,2 @@
+export JAVA_HOME=/var/vcap/packages/openjdk-11/jre
+export PATH=$JAVA_HOME/bin:$PATH

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -18,6 +18,7 @@ echo "-----> `date`: Deploy"
 echo "-----> `date`: Run test errand"
 bosh -n -d test run-errand openjdk-8-test
 bosh -n -d test run-errand openjdk-9-test
+bosh -n -d test run-errand openjdk-11-test
 
 echo "-----> `date`: Delete deployments"
 bosh -n -d test delete-deployment


### PR DESCRIPTION
My team is upgrading our JDK from 8 to 11 and we would like to start using vendored pacakges. Here's my attempt at a package for OpenJDK 11.

The other packages seem to generate two blobs (`jdk<version>.tar.gz` and `jdk<version>-jdk.tar.gz`), but as far as I can tell only the `jdk<version>.tar.gz` is actually necessary. So the `openjdk-11` package only builds a single blob with the full JDK.

The boot JDK for compiling OpenJDK 11 must be either JDK 10 or 11 (see [here](https://hg.openjdk.java.net/jdk/jdk11/raw-file/tip/doc/building.html#boot-jdk-requirements)), so `build.sh` downloads a GA version of OpenJDK 10 and uses that. The `openjdk-8-jdk` package is still installed via `apt-get` because it provides `keytool` which is used later in the script, but we could instead use `/usr/lib/jvm/jdk-10.0.2/bin/keytool` by downloading OpenJDK 10 earlier and adding it to the `PATH`.

This doesn't include the `build.log` or change to `config/blobs.yml` because those will change when the blob is built and uploaded.