### PR TITLE
Migrate pipeline to CFF managed concourse:

### DIFF
--- a/ci/set-pipeline.sh
+++ b/ci/set-pipeline.sh
@@ -4,9 +4,9 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 set -eu
 
-CONCOURSE_URL='https://concourse.cf-denver.com/'
+CONCOURSE_URL='https://bosh.ci.cloudfoundry.org/'
 TARGET_NAME='production'
-TEAM_NAME='healthwatch'
+TEAM_NAME='main'
 
 function authorized() {
   fly --target "$TARGET_NAME" status &> /dev/null
@@ -24,5 +24,4 @@ authorized || login
 
 fly --target production set-pipeline \
     --pipeline java-release \
-    --config "$DIR"/pipeline.yml \
-	  --load-vars-from <(lpass show --note "bosh-packages-concourse-vars-java-release")
+    --config "$DIR"/pipeline.yml


### PR DESCRIPTION
https://bosh.ci.cloudfoundry.org/teams/main/pipelines/java-release

The secrets have already been migrated to the community credhub.
Also the pipeline has already been setup.

This PR is just to update the set-pipeline script to reflect these changes.