### PR TITLE
migrate from AdoptOpenJDK API to Adoptium

### DIFF
--- a/ci/get_release.sh
+++ b/ci/get_release.sh
@@ -4,16 +4,15 @@ set -eu
 
 apt update &> /dev/null && apt install -y curl &> /dev/null
 
-ADOPTOPENJDK_API='https://api.adoptopenjdk.net'
+ADOPTIUM_API='https://api.adoptium.net'
 
 echo "Fetching latest Java ${JAVA_VERSION} JDK for Linux"
 printf "\n\n"
 
-jdk_download_url="$ADOPTOPENJDK_API/v3/binary/latest/$JAVA_VERSION/ga/linux/x64/jdk/hotspot/normal/adoptopenjdk?project=jdk"
+jdk_download_url="$ADOPTIUM_API/v3/binary/latest/$JAVA_VERSION/ga/linux/x64/jdk/hotspot/normal/eclipse?project=jdk"
 
 echo "Fetching ${jdk_download_url}"
 (
   mkdir -p jdk/ && cd jdk/
   curl -JLO "${jdk_download_url}"
 )
-


### PR DESCRIPTION
The AdoptOpenJDK API has been deprecated for some time in favour of the Eclipse Temurin API